### PR TITLE
Add blockingRead and ability to use new Instance of RxPaper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,18 +18,15 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
-
 allprojects {
     repositories {
         jcenter()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Feb 19 21:28:25 GMT 2017
+#Sat Sep 16 16:46:23 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -23,13 +23,13 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 25
-        versionCode 1
-        versionName "1.0.0"
+        versionCode 2
+        versionName "1.0.1"
     }
     buildTypes {
         release {

--- a/library/src/main/java/com/pacoworks/rxpaper2/RxPaperBook.java
+++ b/library/src/main/java/com/pacoworks/rxpaper2/RxPaperBook.java
@@ -40,7 +40,7 @@ import io.reactivex.functions.Action;
 import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
 import io.reactivex.schedulers.Schedulers;
-import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.Subject;
 
 /**
@@ -149,7 +149,7 @@ public class RxPaperBook {
         synchronized (mUpdatesSubjectMap) {
             Subject updates = mUpdatesSubjectMap.get(name);
             if (updates == null) {
-                updates = PublishSubject.<Pair<String, ?>>create().toSerialized();
+                updates = BehaviorSubject.<Pair<String, ?>>create().toSerialized();
                 mUpdatesSubjectMap.put(name, updates);
             }
             return updates;

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -22,15 +22,15 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.3'
+    compileSdkVersion 25
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         applicationId "com.pacoworks.rxpaper.sample"
         minSdkVersion 15
-        targetSdkVersion 23
-        versionCode 1
-        versionName "1.0.0"
+        targetSdkVersion 25
+        versionCode 2
+        versionName "1.0.1"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/tests/src/androidTest/java/com/pacoworks/rxpaper2/RxPaperBookTest.java
+++ b/tests/src/androidTest/java/com/pacoworks/rxpaper2/RxPaperBookTest.java
@@ -276,7 +276,7 @@ public class RxPaperBookTest {
 
                     @Override
                     public void onNext(ComplexObject complexObject) {
-                        Assert.fail("Expected nothing");
+                        Assert.assertEquals(newValue, complexObject);
                     }
                 });
         book.write(key, wrongValue).test().assertComplete().assertNoErrors();

--- a/tests/src/androidTest/java/com/pacoworks/rxpaper2/RxPaperBookTest.java
+++ b/tests/src/androidTest/java/com/pacoworks/rxpaper2/RxPaperBookTest.java
@@ -91,7 +91,7 @@ public class RxPaperBookTest {
         final String key = "hello";
         final ComplexObject value = ComplexObject.random();
         book.write(key, value).subscribe();
-        final TestObserver<ComplexObject> testSubscriber = book.<ComplexObject> read(key).test();
+        final TestObserver<ComplexObject> testSubscriber = book.<ComplexObject>read(key).test();
         testSubscriber.awaitTerminalEvent();
         testSubscriber.assertComplete();
         testSubscriber.assertNoErrors();
@@ -99,11 +99,11 @@ public class RxPaperBookTest {
         testSubscriber.assertValues(value);
         // notFoundSubscriber
         String noKey = ":(";
-        final TestObserver<ComplexObject> notFoundSubscriber = book.<ComplexObject> read(noKey).test();
+        final TestObserver<ComplexObject> notFoundSubscriber = book.<ComplexObject>read(noKey).test();
         notFoundSubscriber.awaitTerminalEvent();
         notFoundSubscriber.assertError(IllegalArgumentException.class);
         // incorrectTypeSubscriber
-        book.<Integer> read(key).subscribe(new SingleObserver<Integer>() {
+        book.<Integer>read(key).subscribe(new SingleObserver<Integer>() {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -124,7 +124,7 @@ public class RxPaperBookTest {
         });
         // immutable objects
         book.write(key, new ImmutableObject(key)).subscribe();
-        final TestObserver<ImmutableObject> immutableReadSubscriber = book.<ImmutableObject> read(key).test();
+        final TestObserver<ImmutableObject> immutableReadSubscriber = book.<ImmutableObject>read(key).test();
         immutableReadSubscriber.awaitTerminalEvent();
         immutableReadSubscriber.assertNoErrors();
         immutableReadSubscriber.assertComplete();
@@ -137,7 +137,7 @@ public class RxPaperBookTest {
         final String key = "hello";
         final ComplexObject value = ComplexObject.random();
         book.write(key, value).subscribe();
-        final TestObserver<ComplexObject> testSubscriber = book.<ComplexObject> read(key).test();
+        final TestObserver<ComplexObject> testSubscriber = book.<ComplexObject>read(key).test();
         testSubscriber.awaitTerminalEvent();
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
@@ -151,7 +151,7 @@ public class RxPaperBookTest {
         notFoundSubscriber.assertValueCount(1);
         notFoundSubscriber.assertValues(defaultValue);
         // incorrectTypeSubscriber
-        book.<Integer> read(key).subscribe(new SingleObserver<Integer>() {
+        book.<Integer>read(key).subscribe(new SingleObserver<Integer>() {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -181,7 +181,7 @@ public class RxPaperBookTest {
         errorSubscriber.assertComplete();
         errorSubscriber.assertNoErrors();
         book.write(key, ComplexObject.random()).subscribe();
-        final TestObserver<Void> testSubscriber = book.<ComplexObject> delete(key).test();
+        final TestObserver<Void> testSubscriber = book.<ComplexObject>delete(key).test();
         testSubscriber.awaitTerminalEvent();
         testSubscriber.assertComplete();
         testSubscriber.assertNoErrors();
@@ -246,7 +246,7 @@ public class RxPaperBookTest {
         final String key = "hello";
         final ComplexObject value = ComplexObject.random();
         final TestSubscriber<ComplexObject> updatesSubscriber = TestSubscriber.create();
-        book.<ComplexObject> observeUnsafe(key, BackpressureStrategy.MISSING).subscribe(updatesSubscriber);
+        book.<ComplexObject>observeUnsafe(key, BackpressureStrategy.MISSING).subscribe(updatesSubscriber);
         updatesSubscriber.assertValueCount(0);
         book.write(key, value).subscribe();
         updatesSubscriber.assertValueCount(1);
@@ -303,5 +303,20 @@ public class RxPaperBookTest {
         updatesSubscriber.assertValueCount(2);
         updatesSubscriber.assertValues(value, newValue);
         updatesSubscriber.assertNoErrors();
+    }
+
+    @Test
+    public void testBlockingReadWithDefault() throws Exception {
+        RxPaperBook book = RxPaperBook.with("READ_WITH_DEFAULT", Schedulers.trampoline());
+        final String key = "hello";
+        final ComplexObject value = ComplexObject.random();
+        book.write(key, value).subscribe();
+
+        final ComplexObject defaultValue = ComplexObject.random();
+        ComplexObject existingResult = book.blockingRead(key, defaultValue);
+        Assert.assertEquals(value, existingResult);
+
+        ComplexObject defaultResult = book.blockingRead(key, defaultValue);
+        Assert.assertEquals(defaultValue, defaultResult);
     }
 }


### PR DESCRIPTION
- I had some use case where I need to read without reactive pattern, so I open an api for this.
- In addition, instead having RxPaper app scope singleton, I give the lib the capability to use a new RxPaper object to observe written values in a named book from others RxPaper instance. Paper work like that with book, so I think this is more convenient.
- As I can trigger an subscriber for observe later from a write, I switched the RxSubject to Behavior Subject in order to get the latest value. It is commun that is there is value in the base, observe change will emit the current value. A test observeUnsafe required to be updated. So current behavior change at lib bound (it should not disturbe current normal usage)