### PR TITLE
Added observe function for any key

### DIFF
--- a/library/src/main/java/com/pacoworks/rxpaper2/RxPaperBook.java
+++ b/library/src/main/java/com/pacoworks/rxpaper2/RxPaperBook.java
@@ -383,6 +383,43 @@ public class RxPaperBook {
     }
 
     /**
+     * Naive update subscription for saved objects. Subscription is filtered by type.
+     *
+     * @param backPressureStrategy how the backpressure is handled downstream
+     * @return hot observable
+     */
+    public <T> Flowable<T> observe(final Class<T> clazz, BackpressureStrategy backPressureStrategy) {
+        return updates.toFlowable(backPressureStrategy)
+                .map(new Function<Pair<String, ?>, Object>() {
+                    @Override
+                    public Object apply(Pair<String, ?> stringPair) {
+                        return stringPair.second;
+                    }
+                }).ofType(clazz);
+    }
+
+    /**
+     * Naive update subscription for saved objects.
+     * <p/>
+     * This method will return all objects casted unsafely, and throw
+     * {@link ClassCastException} if types do not match. For a safely checked and filtered version
+     * use {@link this#observe(Class, BackpressureStrategy)}.
+     *
+     * @param backPressureStrategy how the backpressure is handled downstream
+     * @return hot observable
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Flowable<T> observeUnsafe(BackpressureStrategy backPressureStrategy) {
+        return updates.toFlowable(backPressureStrategy)
+                .map(new Function<Pair<String, ?>, T>() {
+                    @Override
+                    public T apply(Pair<String, ?> stringPair) {
+                        return (T) stringPair.second;
+                    }
+                });
+    }
+
+    /**
      * Checks whether the current book contains the key given
      *
      * @param key the key to look up

--- a/library/src/main/java/com/pacoworks/rxpaper2/RxPaperBook.java
+++ b/library/src/main/java/com/pacoworks/rxpaper2/RxPaperBook.java
@@ -388,7 +388,7 @@ public class RxPaperBook {
      * @param backPressureStrategy how the backpressure is handled downstream
      * @return hot observable
      */
-    public <T> Flowable<T> observe(final Class<T> clazz, BackpressureStrategy backPressureStrategy) {
+    public <T> Flowable<T> observeAll(final Class<T> clazz, BackpressureStrategy backPressureStrategy) {
         return updates.toFlowable(backPressureStrategy)
                 .map(new Function<Pair<String, ?>, Object>() {
                     @Override
@@ -403,13 +403,13 @@ public class RxPaperBook {
      * <p/>
      * This method will return all objects casted unsafely, and throw
      * {@link ClassCastException} if types do not match. For a safely checked and filtered version
-     * use {@link this#observe(Class, BackpressureStrategy)}.
+     * use {@link this#observeAll(Class, BackpressureStrategy)}.
      *
      * @param backPressureStrategy how the backpressure is handled downstream
      * @return hot observable
      */
     @SuppressWarnings("unchecked")
-    public <T> Flowable<T> observeUnsafe(BackpressureStrategy backPressureStrategy) {
+    public <T> Flowable<T> observeAllUnsafe(BackpressureStrategy backPressureStrategy) {
         return updates.toFlowable(backPressureStrategy)
                 .map(new Function<Pair<String, ?>, T>() {
                     @Override

--- a/tests/src/androidTest/java/com/pacoworks/rxpaper2/RxPaperBookTest.java
+++ b/tests/src/androidTest/java/com/pacoworks/rxpaper2/RxPaperBookTest.java
@@ -315,7 +315,7 @@ public class RxPaperBookTest {
         final String key = "hello";
         final ComplexObject value = ComplexObject.random();
         final TestSubscriber<ComplexObject> updatesSubscriber = TestSubscriber.create();
-        book.<ComplexObject> observeUnsafe(BackpressureStrategy.MISSING).subscribe(updatesSubscriber);
+        book.<ComplexObject> observeAllUnsafe(BackpressureStrategy.MISSING).subscribe(updatesSubscriber);
         updatesSubscriber.assertValueCount(0);
         book.write(key, value).subscribe();
         updatesSubscriber.assertValueCount(1);
@@ -326,7 +326,7 @@ public class RxPaperBookTest {
         updatesSubscriber.assertValues(value, newValue);
         // Error value
         final int wrongValue = 3;
-        book.<ComplexObject>observeUnsafe(BackpressureStrategy.MISSING)
+        book.<ComplexObject>observeAllUnsafe(BackpressureStrategy.MISSING)
                 .subscribe(new Subscriber<ComplexObject>() {
                     @Override
                     public void onComplete() {
@@ -357,7 +357,7 @@ public class RxPaperBookTest {
         final String key = "hello";
         final ComplexObject value = ComplexObject.random();
         final TestSubscriber<ComplexObject> updatesSubscriber = TestSubscriber.create();
-        book.observe(ComplexObject.class, BackpressureStrategy.MISSING).subscribe(updatesSubscriber);
+        book.observeAll(ComplexObject.class, BackpressureStrategy.MISSING).subscribe(updatesSubscriber);
         updatesSubscriber.assertValueCount(0);
         book.write(key, value).subscribe();
         updatesSubscriber.assertValueCount(1);


### PR DESCRIPTION
Hello, this PR adds two methods: `observe(Class, BackpressureStrategy)` that emit on each write in the book, and the corresponding `observeUnsafe(BackpressureStrategy)`.