### PR TITLE
Replace jcenter with mavenCentral and update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,17 +23,17 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.2.2'
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-    api 'io.paperdb:paperdb:2.7.1'
-    api 'io.reactivex.rxjava2:rxjava:2.2.10'
-    testImplementation 'junit:junit:4.13'
+    api 'io.github.pilgr:paperdb:2.7.1'
+    api 'io.reactivex.rxjava2:rxjava:2.2.21'
+    testImplementation 'junit:junit:4.13.2'
 }


### PR DESCRIPTION
Since [`jcenter` is deprecated](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) and Paper was migrated to `mavenCentral` I'm opening this PR to remove the `jcenter` dependency and update some dependencies.